### PR TITLE
[Bugfix] "extends" formatter spaces

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1595,6 +1595,12 @@ fn needs_space(prev: Option<&PrevToken>, current: &Token) -> bool {
         return false;
     }
 
+    if (curr_text == "extends" && current.kind == TokenKind::Keyword)
+        || (prev_text == "extends" && prev.kind == TokenKind::Keyword)
+    {
+        return true;
+    }
+
     if curr_text == "::" {
         return true;
     }

--- a/tests/formatter/expected/038_class_extension.nut
+++ b/tests/formatter/expected/038_class_extension.nut
@@ -1,0 +1,3 @@
+class Base {}
+
+class Derived extends Base {}

--- a/tests/formatter/input/038_class_extension.nut
+++ b/tests/formatter/input/038_class_extension.nut
@@ -1,0 +1,9 @@
+class
+Base
+{}
+
+class
+Derived
+extends
+Base
+{}

--- a/tests/formatter_tests.rs
+++ b/tests/formatter_tests.rs
@@ -41,6 +41,13 @@ fn test_formatter() {
 
         let output = format_document(&input, &options)
             .unwrap_or_else(|e| panic!("formatting failed for {}: {}", file_name, e));
-        assert_eq!(output, expected, "mismatch for case: {}", file_name);
+        let normalized_output = output.replace("\r\n", "\n");
+        let normalized_expected = expected.replace("\r\n", "\n");
+
+        assert_eq!(
+            normalized_output, normalized_expected,
+            "mismatch for case: {}",
+            file_name
+        );
     }
 }


### PR DESCRIPTION
- Add space **before and after** keyword "extends"
- Add simple test case for keyword "extends"
- Normalize formatter_tests CRLF vs CR/LF output  (not sure about this one, but formater tests kept failing on the first test case)

Addressing this issue:
https://github.com/mnshdw/squirrel-lsp-zed/issues/1